### PR TITLE
fix template so linter doesn't complain!

### DIFF
--- a/template/test/index.test.js
+++ b/template/test/index.test.js
@@ -1,8 +1,8 @@
 var {{camelcase name}} = require('../');
 var assert = require('assert');
 
-describe('{{name}}', function(){
-  it('should work', function(){
+describe('{{name}}', function() {
+  it('should work', function() {
     assert({{camelcase name}});
   });
 });


### PR DESCRIPTION
just a small fix that was bothering me! I had used khaos-node several times and each time my first commit would fail because the template itself is not compliant with our linter

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb-js/khaos-node/6)

<!-- Reviewable:end -->
